### PR TITLE
make deployment/testing a little more concise

### DIFF
--- a/js/packages/botSocket/botSocket.js
+++ b/js/packages/botSocket/botSocket.js
@@ -9,7 +9,7 @@
 // dependencies
 const net = require('net');
 const EventEmitter = require('events');
-const nugLog = require('nugget-logger');
+const { nugLog } = require('nugget-logger');
 const botProtocol = require('botprotocol'), responseTypes = botProtocol.responseTypes;
 
 // set up logger

--- a/js/packages/deploy/deploy.js
+++ b/js/packages/deploy/deploy.js
@@ -84,7 +84,7 @@ async function setupRobot(args) {
     // DEBUG MODE //
     ////////////////
     if (args.local) return new Promise(resolve => {
-        const botArgs = ['--local', '--debug'];
+        const botArgs = ['--local', '--debug', '--logLevel', 'DEBUG'];
         console.log('Starting robot in local and debug mode');
 
         const forkOptions = {

--- a/js/packages/nugget-logger/index.js
+++ b/js/packages/nugget-logger/index.js
@@ -51,4 +51,5 @@ class logger {
 
 }
 
-module.exports = logger;
+module.exports.nugLog = logger;
+module.exports.levels = levels;

--- a/js/packages/remote/index.js
+++ b/js/packages/remote/index.js
@@ -16,15 +16,12 @@
 const net = require('net');
 const EventEmitter = require('events');
 const yargs = require('yargs');
-const nugLog = require('nugget-logger');
+const { nugLog, levels } = require('nugget-logger');
 const { tokenTypes, responseTypes, responseToken } = require('botprotocol');
 
-// set up logger
-const logger = new nugLog('info', 'remote.log');
-
-// make process.send do nothing if botServer was not spawned as a child process
+// if botServer wasn't spawned as a child process, make process.send do nothing
 process.send = process.send || function() {};
-// exit on any message from parent process
+// exit on any message from parent process (if it exists)
 process.on('message', process.exit);
 
 /*
@@ -43,11 +40,20 @@ const args = yargs
     .option('l', {
         alias: 'local',
         desc: 'run the server on localhost',
-        type: 'boolean',
-        implies: 'debug'
+        type: 'boolean'
+    })
+    .option('L', {
+        alias: 'logLevel',
+        desc: 'specify the logging level to use',
+        type: 'string',
+        choices: levels,
+        default: 'INFO'
     })
     .alias('h', 'help')
     .argv;
+
+// set up logger
+const logger = new nugLog(args.logLevel, 'remote.log');
 
 if (args.debug) logger.i('startup', 'running in debug mode');
 

--- a/js/packages/surface/index.js
+++ b/js/packages/surface/index.js
@@ -8,7 +8,7 @@ const http = require('http');
 const yargs = require('yargs');
 const express = require('express');
 const io = require('socket.io');
-const nugLog = require('nugget-logger');
+const { nugLog } = require('nugget-logger');
 const Controller = require('controller');
 const BotSocket = require('botsocket');
 


### PR DESCRIPTION
- spawn bot server with debug logging level when deployed locally
- export nugget logger as nugLog instead of default
- export nugget-logger levels too
- add logging level argument to bot server